### PR TITLE
Refactor JSONSource and YAMLSource

### DIFF
--- a/api/data_source_base.py
+++ b/api/data_source_base.py
@@ -1,0 +1,125 @@
+from abc import abstractmethod
+from typing import Any, Dict, Type
+
+from api.data_source import DataSourcePlugin
+from api.models.graph import Graph, GraphBuilder
+
+
+class BaseGraphSource(DataSourcePlugin):
+    """Base class for graph data source plugins."""
+
+    def __init__(self, graph_builder_class: Type[GraphBuilder]):
+        self.graph_builder_class = graph_builder_class
+
+    def _coerce_bool(self, value: Any, field_name: str) -> bool:
+        """Convert bool-ish values to bool."""
+        if isinstance(value, bool):
+            return value
+
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1", "yes", "y", "on"}:
+                return True
+            if normalized in {"false", "0", "no", "n", "off"}:
+                return False
+
+        if isinstance(value, (int, float)):
+            if value == 1:
+                return True
+            if value == 0:
+                return False
+
+        raise ValueError(f"'{field_name}' must be a boolean value")
+
+    def _normalize_id(self, raw_id: Any, field_name: str) -> str:
+        """Normalize ID to non-empty string."""
+        if raw_id is None:
+            raise ValueError(f"'{field_name}' cannot be null")
+
+        normalized = str(raw_id).strip()
+        if normalized == "":
+            raise ValueError(f"'{field_name}' cannot be empty")
+
+        return normalized
+
+    def _parse_data(self, data: Dict, directed: Any) -> Graph:
+        """Parse data dict with coerced directed parameter."""
+        return self._build_from_dict(data, directed=self._coerce_bool(directed, "directed"))
+
+    def _build_from_dict(self, data: Dict, directed: bool = True) -> Graph:
+        """Build graph from dict with nodes and edges."""
+        if data is None:
+            raise ValueError("Data cannot be null")
+
+        if not isinstance(data, dict):
+            raise ValueError("Data must be a dict")
+
+        builder = self.graph_builder_class(directed=directed)
+        node_ids = set()
+        edge_ids = set()
+
+        # Add nodes
+        nodes = data.get('nodes', [])
+        if not isinstance(nodes, list):
+            raise ValueError("'nodes' must be a list")
+
+        for node_data in nodes:
+            if not isinstance(node_data, dict):
+                raise ValueError("Each node must be an object")
+
+            if 'id' not in node_data:
+                raise ValueError("Each node must have an 'id' field")
+
+            node_id = self._normalize_id(node_data.get('id'), 'id')
+            if node_id in node_ids:
+                raise ValueError(f"Duplicate node id found: {node_id}")
+            node_ids.add(node_id)
+
+            # Extract all other fields as properties
+            properties = {k: v for k, v in node_data.items() if k != 'id'}
+            builder.add_node(node_id, **properties)
+
+        # Add edges
+        edges = data.get('edges', [])
+        if not isinstance(edges, list):
+            raise ValueError("'edges' must be a list")
+
+        for edge_data in edges:
+            if not isinstance(edge_data, dict):
+                raise ValueError("Each edge must be an object")
+
+            required_fields = ['id', 'source', 'target']
+            missing = [
+                field for field in required_fields if field not in edge_data]
+            if missing:
+                raise ValueError(
+                    "Each edge must have 'id', 'source', and 'target' fields")
+
+            edge_id = self._normalize_id(edge_data.get('id'), 'id')
+            source = self._normalize_id(edge_data.get('source'), 'source')
+            target = self._normalize_id(edge_data.get('target'), 'target')
+
+            if edge_id in edge_ids:
+                raise ValueError(f"Duplicate edge id found: {edge_id}")
+            edge_ids.add(edge_id)
+
+            if source not in node_ids:
+                raise ValueError(
+                    f"Edge '{edge_id}' references unknown source node: {source}")
+            if target not in node_ids:
+                raise ValueError(
+                    f"Edge '{edge_id}' references unknown target node: {target}")
+
+            # All other fields are considered properties of the edge
+            properties = {k: v for k, v in edge_data.items()
+                          if k not in ['id', 'source', 'target']}
+
+            builder.add_edge(edge_id, source, target, **properties)
+
+        # Build graph
+        return builder.build()
+
+    @abstractmethod
+    def get_name(self) -> str:
+        """Return the name of the data source plugin."""
+        pass

--- a/plugins/json_data_source_plugin/json_plugin/__init__.py
+++ b/plugins/json_data_source_plugin/json_plugin/__init__.py
@@ -4,7 +4,7 @@ JSON Data Source Plugin for Graph Visualization Platform.
 This plugin provides functionality to load graph data from JSON files.
 """
 
-from plugins.json_data_source_plugin.json_plugin.json_plugin import JSONSource
+from .json_plugin import JSONSource
 
 # Explicitly export the main class
 __all__ = ['JSONSource']

--- a/plugins/json_data_source_plugin/json_plugin/json_plugin.py
+++ b/plugins/json_data_source_plugin/json_plugin/json_plugin.py
@@ -2,12 +2,12 @@ import json
 import os
 from typing import Dict, Type, List, Any
 
-from api.data_source import DataSourcePlugin
+from api.data_source_base import BaseGraphSource
 from api.models.graph import Graph
 from api.models.graph import GraphBuilder
 
 
-class JSONSource(DataSourcePlugin):
+class JSONSource(BaseGraphSource):
     """
     JSONSource is a data source plugin that provides functionality to read JSON data from a specified file path.
     Returns the data as a Graph object.
@@ -15,14 +15,11 @@ class JSONSource(DataSourcePlugin):
 
     plugin_name = "json_source"
 
-    def __init__(self, graph_builder_class: Type[GraphBuilder]):
-        self.graph_builder_class = graph_builder_class
-
     @classmethod
     def get_parameters_spec(cls) -> List[Dict[str, Any]]:
         """
         Returns the parameter specification for this plugin.
-        
+
         Returns:
             List of parameter definitions, each containing:
             - name: parameter name
@@ -73,7 +70,7 @@ class JSONSource(DataSourcePlugin):
 
         Raises:
             FileNotFoundError: if the JSON file is not found
-            json.JSONDecodeError: if the JSON file is not valid
+            ValueError: if the JSON file is not valid
             ValueError: if the JSON structure is not as expected
         """
         if not os.path.exists(json_path):
@@ -83,105 +80,21 @@ class JSONSource(DataSourcePlugin):
             with open(json_path, 'r', encoding=encoding) as f:
                 data = json.load(f)
         except json.JSONDecodeError as e:
-            raise json.JSONDecodeError(f"Invalid JSON file: {e}", e.doc, e.pos)
+            raise ValueError(f"Invalid JSON file: {e}") from e
+        except UnicodeDecodeError as e:
+            raise ValueError(
+                f"Cannot decode JSON file with encoding '{encoding}': {e}") from e
 
-        return self._build_from_dict(data, directed=directed)
+        return self._parse_data(data, directed)
 
     def parse_string(self, json_string: str, directed: bool = True) -> Graph:
-        """
-        Parse JSON string and return a Graph instance.
-
-        Args:
-            json_string: JSON string to parse
-            directed: Whether the graph should be directed or undirected
-
-        Returns:
-            Graph instance built from the JSON data
-
-        Raises:
-            json.JSONDecodeError: if the JSON string is not valid
-            ValueError: if the JSON structure is not as expected
-        """
+        """Parse JSON string and return graph."""
         try:
             data = json.loads(json_string)
         except json.JSONDecodeError as e:
-            raise json.JSONDecodeError(f"Invalid JSON string: {e}", e.doc, e.pos)
+            raise ValueError(f"Invalid JSON string: {e}") from e
 
-        return self._build_from_dict(data, directed=directed)
-
-    def _build_from_dict(self, data: Dict, directed: bool = True) -> Graph:
-        """
-        Builds a Graph instance from a dictionary representation of the graph data.
-        Expected JSON structure:
-        {
-            "nodes": [
-                {"id": "node1", "label": "Čvor 1", "weight": 10},
-                {"id": "node2", "label": "Čvor 2", "weight": 20}
-            ],
-            "edges": [
-                {"id": "edge1", "source": "node1", "target": "node2", "weight": 5}
-            ]
-        }
-
-        Args:
-            data: Dictionary containing the graph data with 'nodes' and 'edges' keys
-            directed: Whether the graph should be directed or undirected
-
-        Returns:
-            Graph instance built from the dictionary data
-
-        Raises:
-            ValueError: if the data structure is invalid (missing required fields, wrong types)
-        """
-        if not isinstance(data, dict):
-            raise ValueError("JSON must be an object of type dict")
-
-        builder = self.graph_builder_class(directed=directed)
-
-        # Add nodes
-        nodes = data.get('nodes', [])
-        if not isinstance(nodes, list):
-            raise ValueError("'nodes' must be a list")
-
-        for node_data in nodes:
-            if not isinstance(node_data, dict):
-                raise ValueError("Each node must be an object")
-
-            node_id = node_data.get('id')
-            if not node_id:
-                raise ValueError("Each node must have an 'id' field")
-
-            # Extract all other fields as properties
-            properties = {k: v for k, v in node_data.items() if k != 'id'}
-            builder.add_node(node_id, **properties)
-
-        # Add edges
-        edges = data.get('edges', [])
-        if not isinstance(edges, list):
-            raise ValueError("'edges' must be a list")
-
-        for edge_data in edges:
-            if not isinstance(edge_data, dict):
-                raise ValueError("Each edge must be an object")
-
-            edge_id = edge_data.get('id')
-            source = edge_data.get('source')
-            target = edge_data.get('target')
-
-            if not all([edge_id, source, target]):
-                raise ValueError("Each edge must have 'id', 'source', and 'target' fields")
-
-            # All other fields are considered properties of the edge
-            properties = {k: v for k, v in edge_data.items()
-                          if k not in ['id', 'source', 'target']}
-
-            builder.add_edge(edge_id, source, target, **properties)
-
-        # Build graph
-        return builder.build()
+        return self._parse_data(data, directed)
 
     def get_name(self) -> str:
-        """
-        Return the name of the data source plugin.
-        """
         return self.plugin_name

--- a/plugins/yaml_data_source_plugin/yaml_plugin/__init__.py
+++ b/plugins/yaml_data_source_plugin/yaml_plugin/__init__.py
@@ -4,12 +4,12 @@ YAML Data Source Plugin for Graph Visualization Platform.
 This plugin provides functionality to load graph data from YAML files.
 """
 
-from plugins.yaml_data_source_plugin.yaml_plugin.yaml_plugin import YAMLSource
+from .yaml_plugin import YAMLSource
 
 # Explicitly export the main class
-_all_ = ['YAMLSource']
+__all__ = ['YAMLSource']
 
 # Add plugin metadata for discovery
-_version_ = '0.1.0'
-_plugin_name_ = 'yaml_source'
-_plugin_type_ = 'data_source'
+__version__ = '0.1.0'
+__plugin_name__ = 'yaml_source'
+__plugin_type__ = 'data_source'

--- a/plugins/yaml_data_source_plugin/yaml_plugin/yaml_plugin.py
+++ b/plugins/yaml_data_source_plugin/yaml_plugin/yaml_plugin.py
@@ -2,21 +2,18 @@ import yaml
 import os
 from typing import Any, List, Type, Dict
 
-from api.data_source import DataSourcePlugin
+from api.data_source_base import BaseGraphSource
 from api.models.graph import Graph
 from api.models.graph import GraphBuilder
 
 
-class YAMLSource(DataSourcePlugin):
+class YAMLSource(BaseGraphSource):
     """
     YAMLSource is a data source plugin that provides functionality to read YAML data from a specified file path.
     Returns the data as a Graph object.
     """
 
     plugin_name = 'yaml_source'
-
-    def __init__(self, graph_builder_class: Type[GraphBuilder]):
-        self.graph_builder_class = graph_builder_class
 
     def parse(self, yaml_path: str, directed: bool = True, encoding: str = "utf-8", **kwargs) -> Graph:
         """
@@ -33,8 +30,7 @@ class YAMLSource(DataSourcePlugin):
 
         Raises:
             FileNotFoundError: if the YAML file is not found
-            yaml.YAMLError: if the YAML file is malformed
-            ValueError: if the YAML structure is not as expected
+            ValueError: if the YAML file is malformed or structure is invalid
         """
         if not os.path.exists(yaml_path):
             raise FileNotFoundError(f"YAML file not found: {yaml_path}")
@@ -43,83 +39,19 @@ class YAMLSource(DataSourcePlugin):
             with open(yaml_path, 'r', encoding=encoding) as f:
                 data = yaml.safe_load(f)
         except yaml.YAMLError as e:
-            raise yaml.YAMLError(f"Invalid YAML file: {e}")
+            raise ValueError(f"Invalid YAML file: {e}") from e
+        except UnicodeDecodeError as e:
+            raise ValueError(
+                f"Cannot decode YAML file with encoding '{encoding}': {e}") from e
 
-        return self._build_from_dict(data, directed=directed)
+        if data is None:
+            raise ValueError("YAML file is empty")
+
+        return self._parse_data(data, directed)
 
     def _build_from_dict(self, data: Dict, directed: bool = True) -> Graph:
-        """
-        Builds a Graph instance from a dictionary representation of the graph data.
-        Expected YAML structure:
-        nodes:
-          - id: node1
-            label: Čvor 1
-            weight: 10
-          - id: node2
-            label: Čvor 2
-            weight: 20
-        edges:
-          - id: edge1
-            source: node1
-            target: node2
-            weight: 5
-
-        Args:
-            data: Dictionary containing the graph data with 'nodes' and 'edges' keys
-            directed: Whether the graph should be directed or undirected
-
-        Returns:
-            Graph instance built from the dictionary data
-
-        Raises:
-            ValueError: if the data structure is invalid (missing required fields, wrong types)
-        """
-        if not isinstance(data, dict):
-            raise ValueError(f"YAML must be an object of type dict")
-
-        builder = self.graph_builder_class(directed=directed)
-
-        # Add nodes
-        nodes = data.get('nodes', [])
-        if not isinstance(nodes, list):
-            raise ValueError("'nodes' must be a list")
-
-        for node_data in nodes:
-            if not isinstance(node_data, dict):
-                raise ValueError("Each node must be an object")
-
-            node_id = node_data.get('id')
-            if not node_id:
-                raise ValueError("Each node must have an 'id' field")
-
-            # Extract all other fields as properties
-            properties = {k: v for k, v in node_data.items() if k != 'id'}
-            builder.add_node(node_id, **properties)
-
-        # Add edges
-        edges = data.get('edges', [])
-        if not isinstance(edges, list):
-            raise ValueError("'edges' must be a list")
-
-        for edge_data in edges:
-            if not isinstance(edge_data, dict):
-                raise ValueError("Each edge must be an object")
-
-            edge_id = edge_data.get('id')
-            source = edge_data.get('source')
-            target = edge_data.get('target')
-
-            if not all([edge_id, source, target]):
-                raise ValueError("Each edge must have 'id', 'source', and 'target' fields")
-
-            # All other fields are considered properties of the edge
-            properties = {k: v for k, v in edge_data.items()
-                          if k not in ['id', 'source', 'target']}
-
-            builder.add_edge(edge_id, source, target, **properties)
-
-        # Build graph
-        return builder.build()
+        """Build graph from dict using base implementation."""
+        return super()._build_from_dict(data, directed)
 
     def get_name(self) -> str:
         """
@@ -131,7 +63,7 @@ class YAMLSource(DataSourcePlugin):
     def get_parameters_spec(cls) -> List[Dict[str, Any]]:
         """
         Returns the parameter specification for this plugin.
-        
+
         Returns:
             List of parameter definitions, each containing:
             - name: parameter name


### PR DESCRIPTION
Shared logic should be extracted into a common base class (e.g. BaseGraphSource).
Both JSONSource and YAMLSource should reuse this shared implementation.
YAML plugin should explicitly handle empty input (None) with a clear error message.
Error handling should be consistent across both plugins.